### PR TITLE
[misc] Code style fixes, update style doc

### DIFF
--- a/docs/style.md
+++ b/docs/style.md
@@ -160,7 +160,7 @@ Class names should be prefixed according to whether the class is an interface (`
 3. **Pull Requests:**
    * PR descriptions should be informative and clearly indicate the goals of the PR and testing status.
    * Title written in present or imperative tense.
-   * *Types*: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `build`, `perf`.
+   * *Types*: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `build`, `perf`, `misc`.
    * At least one approving review required; reviewers use GitHub Suggested Changes.
    * When creating a pull request, always use the PR template:
 

--- a/docs/style.md
+++ b/docs/style.md
@@ -52,6 +52,7 @@
 | Class / Struct     | `UpperCamelCase`   | `CMainWindow`                  |
 | Function           | `lowerCamelCase`   | `createActions()`              |
 | Variable           | `lowerCamelCase`   | `fileSize`                     |
+| Member Variable    | `m_lowerCamelCase` | `m_matchText`                  |
 | Enum type          | `UpperCamelCase`   | `ErrorCode`                    |
 | Macro              | `ALL_CAPS_SNAKE`   | `MAX_BUFFER_SIZE`              |
 | Template parameter | `UpperCamelCase`   | `template<typename ValueType>` |

--- a/program/include/ui/IFilterWidget.hpp
+++ b/program/include/ui/IFilterWidget.hpp
@@ -20,5 +20,5 @@ public:
      *
      * NOTE: The caller takes ownership of the returned filter object and is responsible for deleting it.
      */
-    virtual IFilter* createFilter() = 0;
+    virtual IFilter *createFilter() = 0;
 };

--- a/program/src/ui/CFilterBuildWidget.cpp
+++ b/program/src/ui/CFilterBuildWidget.cpp
@@ -9,7 +9,7 @@
 // Qt MOC source file
 #include "ui/moc_CFilterBuildWidget.cpp"
 
-CFilterBuildWidget::CFilterBuildWidget(QWidget* parent)
+CFilterBuildWidget::CFilterBuildWidget(QWidget *parent)
     : QWidget(parent)
 {
     // Create combo box
@@ -42,9 +42,9 @@ CFilterBuildWidget::CFilterBuildWidget(QWidget* parent)
             this, &CFilterBuildWidget::onAddFilterClicked);
 
     // Lay out widgets
-    QVBoxLayout* mainLayout = new QVBoxLayout(this);
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
 
-    QHBoxLayout* comboLayout = new QHBoxLayout();
+    QHBoxLayout *comboLayout = new QHBoxLayout();
     comboLayout->addWidget(new QLabel(tr("Filter by:"), this));
     comboLayout->addWidget(m_filterTypeCombo);
 

--- a/program/src/ui/CFilterListWidget.cpp
+++ b/program/src/ui/CFilterListWidget.cpp
@@ -29,11 +29,11 @@ CFilterListWidget::CFilterListWidget(QWidget *parent)
             this, &CFilterListWidget::onRemoveFilterClicked);
 
     // Layout
-    QVBoxLayout* mainLayout = new QVBoxLayout(this);
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
     mainLayout->addWidget(m_filterBuildWidget);
     mainLayout->addWidget(m_filterListView);
 
-    QHBoxLayout* buttonLayout = new QHBoxLayout();
+    QHBoxLayout *buttonLayout = new QHBoxLayout();
     buttonLayout->addStretch();
     buttonLayout->addWidget(m_removeButton);
 

--- a/program/src/ui/CFolderListWidget.cpp
+++ b/program/src/ui/CFolderListWidget.cpp
@@ -29,8 +29,8 @@ CFolderListWidget::CFolderListWidget(QWidget *parent)
             this, &CFolderListWidget::onRemoveFolderClicked);
 
     // Layout
-    QVBoxLayout* mainLayout = new QVBoxLayout(this);
-    QHBoxLayout* buttonLayout = new QHBoxLayout();
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    QHBoxLayout *buttonLayout = new QHBoxLayout();
     
     buttonLayout->addWidget(m_addButton);
     buttonLayout->addWidget(m_removeButton);

--- a/program/src/ui/CSearchResultModel.cpp
+++ b/program/src/ui/CSearchResultModel.cpp
@@ -41,8 +41,8 @@ QVariant CSearchResultModel::headerData(int section,
 }
 
 
-QVariant CSearchResultModel::data(const QModelIndex& index, int role) const {
-    if (!index.isValid() || role != Qt::DisplayRole) {
+QVariant CSearchResultModel::data(QModelIndex const &index, int role) const {
+    if(!index.isValid() || role != Qt::DisplayRole) {
         return QVariant();
     }
 

--- a/program/src/ui/IFilterWidget.cpp
+++ b/program/src/ui/IFilterWidget.cpp
@@ -4,7 +4,7 @@
 // Qt MOC source file
 #include "ui/moc_IFilterWidget.cpp"
 
-IFilterWidget::IFilterWidget(QWidget* parent)
+IFilterWidget::IFilterWidget(QWidget *parent)
     : QWidget(parent)
 {
     // nothing to do


### PR DESCRIPTION
This PR addresses some inconsistent code style (especially pointer * and qualifiers being in the wrong order) in the GUI code. The code was revised to use the same style as in the style guide.

Also some changes to the code style guide:
- Clarify naming convention for class member variables
- Add `misc` PR type tag.

- [X] My code follows the style guide (`docs/style.md`)
- [ ] Unit tests were added
- [ ] Unit tests will be added later after some review
- [X] Unit tests weren't necessary