### PR TITLE
[fix] Fix a problem with buffered search/match

### DIFF
--- a/searchlib/src/search/CStreamSearcher.cpp
+++ b/searchlib/src/search/CStreamSearcher.cpp
@@ -76,6 +76,8 @@ bool CStreamSearcher::searchText(std::wistream &in) const {
             }
         }
 
+        bufferPos += bufferLen;
+
         // At this point, if the buffer window should be offset,
         // then we should rewind
         if(!in.eof() && overlapChars > 0) {


### PR DESCRIPTION
This PR addresses the problem detailed in this issue: https://github.com/JFarNTIG/LightningSearch/issues/3

In `CStreamSearcher`, the buffer position was not being updated properly, so the loop was comparing chunks incorrectly. After adding a line to update buffer position, the unit test is now passing.

- [X] My code follows the style guide (`docs/style.md`)
- [ ] Unit tests were added
- [ ] Unit tests will be added later after some review
- [X] Unit tests weren't necessary