### PR TITLE
[ci] Update CMakeLists with headless build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,18 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Optional unit-tests
 option(BUILD_TESTING "Build unit tests" ON)
 
+# Option for whether the entire GUI program
+# should be built, or just library+unit tests.
+# If only headless unit testing is desired,
+# for example for CI, this can be turned off.
+option(BUILD_GUI "Build main program" ON)
+
 # Add component directories
 add_subdirectory(searchlib)
-add_subdirectory(program)
+
+if(BUILD_GUI)
+    add_subdirectory(program)
+endif()
 
 if(BUILD_TESTING)
     enable_testing()


### PR DESCRIPTION
This PR updates the root CMakeLists with a headless build option. This will be useful when we set up CI with Github Actions.