### PR TITLE
Remove unused code in CSearchEngine

### DIFF
--- a/searchlib/include/search/CSearchEngine.hpp
+++ b/searchlib/include/search/CSearchEngine.hpp
@@ -59,7 +59,4 @@ private:
     std::atomic_int m_totalFilesToSearch;
     std::atomic_int m_totalFilesSearched;
     std::atomic_int m_totalMatches;
-
-    std::mutex m_searchedFilesMutex;
-    std::set<std::wstring> m_searchedFilesSet;
 };

--- a/searchlib/src/search/CSearchEngine.cpp
+++ b/searchlib/src/search/CSearchEngine.cpp
@@ -76,10 +76,6 @@ void CSearchEngine::spawnEnumerateWorker(std::filesystem::path const enumPath) {
 
             paths.push_back(filePath);
 
-            // m_searchedFilesMutex.lock();
-            // m_searchedFilesSet.insert(p.path().wstring());
-            // m_searchedFilesMutex.unlock();
-
             m_totalFilesToSearch++;
 
             if(paths.size() > BATCH_SIZE) {
@@ -113,10 +109,6 @@ void CSearchEngine::spawnSearchWorker(std::vector<std::filesystem::path> fileLis
 
         for(auto &filePath : fileList) {
             m_totalFilesSearched++;
-
-            // m_searchedFilesMutex.lock();
-            // m_searchedFilesSet.erase(filePath.wstring());
-            // m_searchedFilesMutex.unlock();
 
             bool isMatch = matchesAllFilters(filePath);
 


### PR DESCRIPTION
Just commented out some unused code in `CSearchEngine` that was previously used for debugging purposes.

(This PR is also a test of the new CI workflow)

- [X] My code follows the style guide (`docs/style.md`)
- [ ] Unit tests were added
- [ ] Unit tests will be added later after some review
- [X] Unit tests weren't necessary